### PR TITLE
fix bug where multiple units would share a page due to the ID, fix some whitespace issues, flatten selections into single array containing the count for each selection and its name, only show selections in sidebar if there is a duplicate unit with different selections

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -22,7 +22,7 @@ class Builder {
 
   static getMain(roster) {
     const overviewPage = Builder.getOverviewPage(roster);
-    const unitPages = roster.units.map((unit) => Builder.getUnitPage(unit));
+    const unitPages = roster.units.map((unit, index) => Builder.getUnitPage(unit, index));
 
     return `
       <main>
@@ -37,8 +37,8 @@ class Builder {
     return '';
   }
 
-  static getUnitPage(unit) {
-    const id = Builder.stringToId(unit.name);
+  static getUnitPage(unit, index) {
+    const id = Builder.stringToId(unit.name + index);
 
     return `
       <div id="${id}-page" class="page">
@@ -209,24 +209,24 @@ class Builder {
       <aside>
         ${Builder.getToggleAsideButton('X', 'close')}
         ${Builder.getOverviewButton(roster)}
-        ${roster.units.map((unit) => Builder.getUnitButton(unit)).join('')}
+        ${roster.units.map((unit, index) => Builder.getUnitButton(unit, index)).join('')}
       </aside>
     `;
   }
 
-  static getUnitButton(unit) {
-    const id = Builder.stringToId(unit.name);
+  static getUnitButton(unit, index) {
+    const id = Builder.stringToId(unit.name + index);
 
     return `
       <button onclick="togglePage('${id}-page')" id="${id}-button">
         ${unit.name}
-        <div class="overview-info">
-          ${unit.selections.map((selection) => `
+        ${unit.sidebarSelections.length ? `
+          <div class="overview-info">
             <div>
-              <span class="bold">Selections: </span>${selection.join('')}
+              ${unit.sidebarSelections.map((selection) => `${selection.count}x ${selection.name}`).join('<br />')}
             </div>
-          `).join('')}
-        </div>
+          </div>
+        ` : ''}        
       </button>
     `;
   }
@@ -273,18 +273,13 @@ class Builder {
   }
 
   static getTooltip(text, description) {
-    return `
-      <span class="tooltip-on-hover">
-        ${text}
-        <div class="tooltip">
-          <span class="bold">
-            ${text}:¨
-          </span>
-          <br />
-          ${description}
-        </div>
-      </span>
-    `;
+    return `<span class="tooltip-on-hover">${text}<div class="tooltip">
+        <span class="bold">
+          ${text}:
+        </span>
+        <br />
+        ${description}
+      </div></span>`;
   }
 
   static stringToId(string) {

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -163,7 +163,7 @@ class Interpreter {
           const strength = matches[4] || '';
           const armorPenetration = matches[5] || '';
           const damage = matches[6] || '';
-          const keywords = matches[7].replace('-', '').split(',').filter((keyword) => !!keyword) || '';
+          const keywords = matches[7].replace('-', '').split(',').map((keyword) => keyword.trim()).filter((keyword) => !!keyword) || '';
 
           weapons.push({
             name,
@@ -486,7 +486,7 @@ class Interpreter {
 
   static getArrayFromHtml(htmlElement, separator = ',') {
     if (Interpreter.elementExists(htmlElement)) {
-      return htmlElement.innerHTML.trim().split(separator);
+      return htmlElement.innerHTML.trim().split(separator).map((keyword) => keyword.trim();
     } else {
       return [];
     }

--- a/src/template.js
+++ b/src/template.js
@@ -241,6 +241,7 @@ button {
   font-size: 1.25rem;
   text-transform: capitalize;
   font-weight: 300;
+  min-height: 100px;
 }
 
 button:hover {


### PR DESCRIPTION
![image](https://github.com/jwinzeler/better-battlescribe-exports/assets/37178713/d41ef802-a992-4f40-a31d-29c8b3f4732b)
