### PR TITLE
Fix accidental removal of inline dashes in keywords, clean up tables empty first column, remove duplicate identical statlines but keep different ones, big text data clean up

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -131,9 +131,8 @@ class Builder {
 
     if (unit.rangedWeapons.length) {
       rangedWeaponsTable = this.createTable([
-        ['', 'RANGED WEAPONS', 'RANGE', 'A', 'BS', 'S', 'AP', 'D'],
+        ['RANGED WEAPONS', 'RANGE', 'A', 'BS', 'S', 'AP', 'D'],
         ...unit.rangedWeapons.map((weapon) => ([
-          '',
           `${weapon.name}${weapon.keywords.length ? `<br /><b class="small">[${weapon.keywords.join(', ')}]` : ''}</b>`,
           weapon.range,
           weapon.attacks,
@@ -147,9 +146,8 @@ class Builder {
 
     if (unit.meleeWeapons.length) {
       meleeWeaponsTable = this.createTable([
-        ['', 'MELEE WEAPONS', 'RANGE', 'A', 'WS', 'S', 'AP', 'D'],
+        ['MELEE WEAPONS', 'RANGE', 'A', 'WS', 'S', 'AP', 'D'],
         ...unit.meleeWeapons.map((weapon) => ([
-          '',
           `${weapon.name}${weapon.keywords.length ? `<br /><b class="small">[${weapon.keywords.join(', ')}]` : ''}</b>`,
           weapon.range,
           weapon.attacks,
@@ -245,20 +243,23 @@ class Builder {
         <div class="unit-name">
           ${unit.name}
         </div>
-        <div class="stats-wrapper">
-          ${unit.stats.map((stats) => `
+          ${unit.stats.map((stats, index) => `
+          <div class="stats-wrapper">
             ${Object.keys(stats).filter((stat) => stat !== 'name').map((stat) => `
               <div class="stat">
-                <div class="stat-name">
-                  ${stat}
-                </div>
+                ${index === 0 ? `
+                  <div class="stat-name">
+                    ${stat}
+                  </div>
+                ` : ''}
                 <div class="stat-value">
                   ${stats[stat]}
                 </div>
               </div>
             `).join('')}
+            ${unit.stats.length > 1 ? `<div class="stats-model-name${index === 0 ? ' first' : ''}">${stats.name}</div>` : ''}
+            </div>
           `).join('')}
-        </div>
       </header>
     `;
   }

--- a/src/parser.js
+++ b/src/parser.js
@@ -163,7 +163,7 @@ class Parser {
           const strength = matches[4] || '';
           const armorPenetration = matches[5] || '';
           const damage = matches[6] || '';
-          const keywords = matches[7].replace('-', '').split(',').map((keyword) => keyword.trim()).filter((keyword) => !!keyword) || '';
+          const keywords = matches[7].replace(/^-$/, '').split(',').map((keyword) => keyword.trim()).filter((keyword) => !!keyword) || '';
 
           weapons.push({
             name,

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -13,11 +13,7 @@ class Sanitizer {
      * - Better styles for toolips
      * - Fix missing space between commas in abilities and keywords
      *  Where to get stratagems?
-     * - Fix movement stat showing : instead of "
      * - Fix CORE abilities, show faction abilities (different values in real datasheet compared to here)
-     * - Add extra graphics elements
-     * 
-     *  Super later on:
      * - check small mobile portait mode
      * 
      */

--- a/src/sanitizer.js
+++ b/src/sanitizer.js
@@ -1,7 +1,9 @@
 class Sanitizer {
   static sanitize(roster) {
     Logger.log('Sanitizing data...');
+    roster = this.cleanUpText(roster);
     roster = this.removeDuplicateUnits(roster);
+    roster = this.removeDuplicateStatlines(roster);
     roster = this.addTooltips(roster, roster.rules);
     roster = this.flattenSelections(roster);
     roster = this.addSidebarSelections(roster);
@@ -11,7 +13,6 @@ class Sanitizer {
      * - Better styles for toolips
      * - Fix missing space between commas in abilities and keywords
      *  Where to get stratagems?
-     * - Fix Stats for multiple stat units (e.g. zoanthropes)
      * - Fix movement stat showing : instead of "
      * - Fix CORE abilities, show faction abilities (different values in real datasheet compared to here)
      * - Add extra graphics elements
@@ -24,6 +25,48 @@ class Sanitizer {
     Logger.log('Finished sanitizing data.');
 
     return roster;
+  }
+
+  static removeDuplicateStatlines(roster) {
+    const isDuplicateStat = (stats, compareStats) => Object.keys(stats).every((key) => {
+      if (key === 'name') {
+        return compareStats[key] !== stats[key];
+      } else {
+        return compareStats[key] === stats[key];
+      }
+    });
+
+    return {
+      ...roster,
+      units: roster.units.map((unit) => ({
+        ...unit,
+        stats: unit.stats.reduce((newStats, current) => {
+          const duplicateStat = newStats.find((stats) => isDuplicateStat(stats, current));
+
+          if (duplicateStat) {
+            duplicateStat.name += `, ${current.name}`;
+          } else {
+            newStats.push(current);
+          }
+          
+          return newStats;
+        }, []),
+      })),
+    };
+  }
+
+  static cleanUpText(roster) {
+    return this.mutateEachStringInObject(roster, (string) => {
+      return string
+        .replace(/(\w)- *?(\w)/g, '$1-$2') // Remove extra spaces with inline dashes (a- b -> a-b)
+        .replace(/  */g, ' ') // Remove double (or more) spaces
+        .replace(/ +\n */g, '\n') // Remove extra spaces around line separators
+        .replace(/ +, */g, ', ') // Remove spaces before and after commas, leave only 1 after
+        .replace(/([A-Z]{3,})/g, (match) => `<b class="capitalize">${match.toLowerCase()}</b>`)
+        // Replace uppercase words with bold capitalized versions
+        .replace(/^(\d):$/g, '$1"') // replace mistake in movement data where : was placed instead of "
+        .trim();
+    });
   }
 
   static addSidebarSelections(roster) {
@@ -93,7 +136,7 @@ class Sanitizer {
           abilityNames: addNestedTooltips(unit.abilities.abilityNames),
           abilities: unit.abilities.abilities.map((ability) => ({
             ...ability,
-            name: addTooltip(ability.name),
+            description: addTooltip(ability.description),
           })),
         },
         keywords: addNestedTooltips(unit.keywords),
@@ -119,6 +162,18 @@ class Sanitizer {
 
   static removeDuplicateFromArray(array) {
     return array.filter((element, index) => array.indexOf(array.find((compareElement) => this.isDeepEqual(compareElement, element))) === index);
+  }
+
+  static mutateEachStringInObject(object, callback) {
+    Object.keys(object).forEach((key) => {
+      if (this.isObject(object[key])) {
+        return this.mutateEachStringInObject(object[key], callback);
+      } else if (typeof object[key] === 'string') {
+        object[key] = callback(object[key]) || '';
+      }
+    });
+
+    return object;
   }
 
   static isDeepEqual(object1, object2) {

--- a/src/template.js
+++ b/src/template.js
@@ -275,12 +275,12 @@ div.overview-info {
   line-height: 1.25rem;
 }
 
-span.bold {
-  font-weight: 500;
+.small {
+  font-size: 0.75rem;
 }
 
-span.small {
-  font-size: 0.75rem;
+.capitalize {
+  text-transform: capitalize;
 }
 
 div.divider {
@@ -337,6 +337,12 @@ div.page.active {
   width: 100%;
   border-collapse: collapse;
   margin-bottom: 1rem;
+  table-layout: fixed;
+}
+
+.datasheet-body .column-left th:first-child,
+.datasheet-body .column-left td:first-child {
+  width: 40%;
 }
 
 .datasheet-body tr:nth-child(odd) {
@@ -349,7 +355,7 @@ div.page.active {
   font-weight: 400;
 }
 
-.datasheet-body th:nth-child(2) {
+.datasheet-body th:first-child {
   text-align: left;
 }
 
@@ -360,10 +366,6 @@ div.page.active {
 }
 
 .datasheet-body td:first-child {
-  width: 2rem;
-}
-
-.datasheet-body td:nth-child(2) {
   text-align: left;
 }
 
@@ -384,7 +386,7 @@ div.page.active {
   padding: .5rem;
   border-radius: 0 0 50% 50%;
   top: -.25rem;
-  left: -3rem;
+  right: 1rem;
   border: 2px solid var(--border-datasheet);
 }
 
@@ -428,6 +430,15 @@ div.page.active {
   justify-content: center;
   align-items: center;
   border: 2px solid var(--border-datasheet);
+}
+
+.stats-model-name {
+  display: flex;
+  align-items: center;
+}
+
+.stats-model-name.first {
+  margin-top: 1rem;
 }
 
 .tooltip-on-hover {
@@ -652,11 +663,6 @@ div#overview-page.active {
 
   .datasheet-body .column-left th:first-child,
   .datasheet-body .column-left td:first-child {
-    display: none;
-  }
-
-  .datasheet-body .column-left th:nth-child(2),
-  .datasheet-body .column-left td:nth-child(2) {
     width: 60%;
   }
 
@@ -668,16 +674,36 @@ div#overview-page.active {
   .column-right .column-padding {
     padding-top: 0;
   }
+
   div#overview-page.active {
     display: block;
   }
+
   div#overview-page .left-column,
   div#overview-page .right-column {
     flex-basis: 100%;
   }
+
   #overview-page .visibility-button {
     display:block;
-  }  
+  }
+
+  .stats-wrapper {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+    width: 100%;
+  }
+
+  .stats-model-name {
+    flex-basis: 100%;
+    justify-content: center;
+  }
+
+  .stats-model-name.first {
+    margin-top: 0;
+  }
 }
 
 /* Landscape */
@@ -685,6 +711,7 @@ div#overview-page.active {
   aside {
     width: 50%;
   }
+
   .datasheet header {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Keywords with dashes
![image](https://github.com/jwinzeler/better-battlescribe-exports/assets/37178713/3ae82c2b-609f-4a64-8f69-7f989725dcbc)

Datasheet with multiple identical statlines
![image](https://github.com/jwinzeler/better-battlescribe-exports/assets/37178713/316d8332-06ea-421f-a6d5-b34bddf63b9b)

Datasheet with multiple different statlines
![image](https://github.com/jwinzeler/better-battlescribe-exports/assets/37178713/a8d87cd4-86e1-4567-9294-5297c2211914)