### PR TITLE
Faction Ability fix

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -26,11 +26,11 @@ class Logger {
   }
 
   static warn(message) {
-    this.writeToElement(`<span class="warn">${message}</span>`);
+    this.writeToElement(`<span class="warn">WARNING: ${message}</span>`);
   }
 
   static error(message) {
-    this.writeToElement(`<span class="error">${message}</span>`);
+    this.writeToElement(`<span class="error">ERROR: ${message}</span>`);
     document.getElementById('log-details')?.setAttribute('open', true);
   }
 }


### PR DESCRIPTION
fix: remove army rules that don't match your most common faction keyword (fix for chaos factions having all chaos faction abilities for some reason)

feat: make errors and warnings in the logger more visible